### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "googlebenchmark"
+description := "A library to benchmark code snippets, similar to unit tests."
+gitrepo     := "https://github.com/google/benchmark.git"
+homepage    := "https://github.com/google/benchmark/"
+version     := 1.5.0 sha256:3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a https://github.com/google/benchmark/archive/v1.5.0.tar.gz
+license     := "Apache-2.0"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

